### PR TITLE
Sepac decoder timezone and sftp ppk delete add

### DIFF
--- a/DecodeSiemensLogs/App.config
+++ b/DecodeSiemensLogs/App.config
@@ -22,7 +22,7 @@
   <applicationSettings>
     <DecodeSiemensLogs.Properties.Settings>
       <setting name="LogPath" serializeAs="String">
-        <value>D:\AlexandriaTest\</value>
+        <value>D:\DownloadedLogs\</value>
       </setting>
       <setting name="WriteToConsole" serializeAs="String">
         <value>True</value>
@@ -37,7 +37,7 @@
         <value>1000</value>
       </setting>
       <setting name="LogsPath" serializeAs="String">
-        <value>D:\AlexandriaTest\</value>
+        <value>D:\DownloadedLogs\</value>
       </setting>
       <setting name="CSVOutPAth" serializeAs="String">
         <value>C:\temp\CSVs</value>
@@ -64,7 +64,7 @@
         <value>10</value>
       </setting>
 	    <setting name="PerfLogOffset" serializeAs="String">
-        <value>10</value>
+        <value>180</value>
       </setting>
     </DecodeSiemensLogs.Properties.Settings>
   </applicationSettings>

--- a/DecodeSiemensLogs/App.config
+++ b/DecodeSiemensLogs/App.config
@@ -22,7 +22,7 @@
   <applicationSettings>
     <DecodeSiemensLogs.Properties.Settings>
       <setting name="LogPath" serializeAs="String">
-        <value>D:\DownloadedLogs\</value>
+        <value>D:\AlexandriaTest\</value>
       </setting>
       <setting name="WriteToConsole" serializeAs="String">
         <value>True</value>
@@ -37,7 +37,7 @@
         <value>1000</value>
       </setting>
       <setting name="LogsPath" serializeAs="String">
-        <value>D:\DownloadedLogs\</value>
+        <value>D:\AlexandriaTest\</value>
       </setting>
       <setting name="CSVOutPAth" serializeAs="String">
         <value>C:\temp\CSVs</value>
@@ -64,7 +64,7 @@
         <value>10</value>
       </setting>
 	    <setting name="PerfLogOffset" serializeAs="String">
-        <value>180</value>
+        <value>10</value>
       </setting>
     </DecodeSiemensLogs.Properties.Settings>
   </applicationSettings>

--- a/DecodeSiemensLogs/Program.cs
+++ b/DecodeSiemensLogs/Program.cs
@@ -680,20 +680,7 @@ namespace DecodeSiemensLogs
                     bool isDayligtSavings = localZone.IsDaylightSavingTime(currentDate);
                     bool isArizona = TimeZoneInfo.Local.Id == "US Mountain Standard Time" || TimeZoneInfo.Local.DisplayName.Contains("Arizona");
                     Console.WriteLine(dataFmt, "Daylight saving time?", isDayligtSavings);
-
                     //var dstOffset = Math.Abs(DateTimeOffset.Now.Offset.Hours);
-                    WriteToConsole("Starting signal " + dirname);
-                    // Get Eastern Time Zone
-                    //TimeZoneInfo easternZone = TimeZoneInfo.FindSystemTimeZoneById("Eastern Standard Time");
-                    //DateTime currentDate = DateTime.Now;
-                    //const string dataFmt = "{0,-30}{1}";
-
-                    //// Check if Eastern timezone is in Daylight Saving Time
-                    //Console.WriteLine(dataFmt, "Daylight saving time?", easternZone.IsDaylightSavingTime(currentDate));
-
-                    //// Convert current time to Eastern time
-                    //DateTime easternTime = TimeZoneInfo.ConvertTime(currentDate, easternZone);
-                    //Console.WriteLine(dataFmt, "Eastern time:", easternTime.ToString());
 
                     WriteToConsole("Starting signal " + dirname);
                     var options1 = new ParallelOptions

--- a/DecodeSiemensLogs/Properties/Settings.Designer.cs
+++ b/DecodeSiemensLogs/Properties/Settings.Designer.cs
@@ -158,7 +158,10 @@ namespace DecodeSiemensLogs.Properties {
                 return ((string)(this["SPM"]));
             }
         }
-        
+
+        [global::System.Configuration.ApplicationScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("180")]
         public int PerfLogOffset {
             get {
                 return ((int)(this["PerfLogOffset"]));

--- a/MOE.Common/Models/SignalFtp.cs
+++ b/MOE.Common/Models/SignalFtp.cs
@@ -1123,11 +1123,34 @@ namespace MOE.Common.Business
                         // Throw on any error
                         transferResult.Check();
 
-                        // Print results
-                        foreach (TransferEventArgs transfer in transferResult.Transfers)
+                        if (SignalFtpOptions.DeleteAfterFtp)
                         {
-                            Console.WriteLine("Download of {0} succeeded", transfer.FileName);
+                            foreach (TransferEventArgs transfer in transferResult.Transfers)
+                            {
+                                Console.WriteLine("Download of {0} succeeded", transfer.FileName);
+
+                                // Construct the full remote path
+                                string remoteFilePath = transfer.FileName;
+
+                                // Make sure we use proper path format based on the server OS
+                                remoteFilePath = remoteFilePath.Replace('\\', '/');
+
+                                // Delete the transferred file
+                                RemovalOperationResult removalResult = session.RemoveFiles(remoteFilePath);
+
+                                // Check for removal errors
+                                try
+                                {
+                                    removalResult.Check();
+                                    Console.WriteLine("Successfully deleted: {0}", remoteFilePath);
+                                }
+                                catch (Exception ex)
+                                {
+                                    Console.WriteLine("Failed to delete {0}: {1}", remoteFilePath, ex.Message);
+                                }
+                            }
                         }
+                        // Print results and delete each file
                     }
                 }
                 catch (Exception e)


### PR DESCRIPTION
**SEPAC AND SFTP CHANGES**

- Removed local time convert to UTC since the SEPAC signals are already on local time. No need to revert back to UTC
- Added logic to delete remote files from the controller after downloaded and confirmed.
- Added Daylight savings check to shift timestamps to correct local time