### PR TITLE
Added Move feature to decoder for WisDot

### DIFF
--- a/NEWDecodeandImportASC3Logs/App.config
+++ b/NEWDecodeandImportASC3Logs/App.config
@@ -16,6 +16,8 @@
   <appSettings>
     <add key="WriteToConsole" value="true" />
     <add key="DeleteFile" value="true" />
+	<add key="Move" value="false" />
+	<add key="MoveLocation" value="" />
     <add key="MaxThreads" value="1" />
     <add key="DestinationTableNAme" value="Controller_Event_Log" />
     <add key="EarliestAcceptableDate" value="2019-01-01" />

--- a/NEWDecodeandImportASC3Logs/Program.cs
+++ b/NEWDecodeandImportASC3Logs/Program.cs
@@ -75,7 +75,7 @@ namespace NEWDecodeandImportASC3Logs
                     MOE.Common.Data.MOE.Controller_Event_LogDataTable elTable = CreateDataTableForImport();
                     AddEventsToImportTable(mergedEventsTable, elTable);
                     mergedEventsTable.Dispose();
-                    BulkImportRecordsAndDeleteFiles(appSettings, toDelete, elTable);
+                    BulkImportRecordsAndDeleteFiles(appSettings, toDelete, elTable, signalId);
                 }
             });
         }
@@ -87,7 +87,7 @@ namespace NEWDecodeandImportASC3Logs
             fileNames = Directory.GetFiles(dir, "*.dat?");
         }
 
-        private static void BulkImportRecordsAndDeleteFiles(NameValueCollection appSettings, ConcurrentBag<string> toDelete, MOE.Common.Data.MOE.Controller_Event_LogDataTable elTable)
+        private static void BulkImportRecordsAndDeleteFiles(NameValueCollection appSettings, ConcurrentBag<string> toDelete, MOE.Common.Data.MOE.Controller_Event_LogDataTable elTable, string signalId)
         {
             string connectionString = ConfigurationManager.ConnectionStrings["SPM"].ConnectionString;
             string destTable = appSettings["DestinationTableNAme"];
@@ -99,11 +99,35 @@ namespace NEWDecodeandImportASC3Logs
                 Convert.ToDateTime(appSettings["EarliestAcceptableDate"]),
                 Convert.ToInt32(appSettings["BulkCopyBatchSize"]),
                 Convert.ToInt32(appSettings["BulkCopyTimeOut"]));
+
+            bool moveEnabled = false;
+            bool.TryParse(appSettings["Move"], out moveEnabled);
+            string moveLocation = appSettings["MoveLocation"];
+            bool useMove = moveEnabled && !string.IsNullOrWhiteSpace(moveLocation);
+
+            bool deleteEnabled = Convert.ToBoolean(appSettings["DeleteFile"]);
+            bool writeToConsole = Convert.ToBoolean(appSettings["WriteToConsole"]);
+
+            if (writeToConsole)
+            {
+                Console.WriteLine("[Signal " + signalId + "] Move=" + moveEnabled +
+                                  ", MoveLocation='" + moveLocation + "', useMove=" + useMove +
+                                  ", DeleteFile=" + deleteEnabled +
+                                  ", FilesQueued=" + toDelete.Count);
+            }
+
             if (elTable.Count > 0)
             {
-                if (MOE.Common.Business.SignalFtp.BulktoDb(elTable, options, destTable) && Convert.ToBoolean(appSettings["DeleteFile"]))
+                if (MOE.Common.Business.SignalFtp.BulktoDb(elTable, options, destTable))
                 {
-                    DeleteFiles(toDelete);
+                    if (useMove)
+                    {
+                        MoveFiles(toDelete, moveLocation, signalId, writeToConsole);
+                    }
+                    else if (deleteEnabled)
+                    {
+                        DeleteFiles(toDelete);
+                    }
                 }
             }
             else
@@ -118,7 +142,14 @@ namespace NEWDecodeandImportASC3Logs
                 }
                 if (td.Count > 0)
                 {
-                    DeleteFiles(td);
+                    if (useMove)
+                    {
+                        MoveFiles(td, moveLocation, signalId, writeToConsole);
+                    }
+                    else
+                    {
+                        DeleteFiles(td);
+                    }
                 }
             }
         }
@@ -181,6 +212,54 @@ namespace NEWDecodeandImportASC3Logs
                 catch (Exception e)
                 {
                     Console.WriteLine(e);
+                }
+            }
+        }
+
+        public static void MoveFiles(ConcurrentBag<string> files, string moveLocation, string signalId,
+            bool writeToConsole)
+        {
+            string destDir;
+            try
+            {
+                destDir = Path.Combine(moveLocation, signalId);
+                Directory.CreateDirectory(destDir);
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine("Failed to create destination directory under '" + moveLocation + "' for signal " + signalId + ": " + e);
+                return;
+            }
+
+            foreach (string f in files)
+            {
+                try
+                {
+                    if (!File.Exists(f))
+                    {
+                        continue;
+                    }
+
+                    string destPath = Path.Combine(destDir, Path.GetFileName(f));
+
+                    // handle name collisions by appending a timestamp before the extension
+                    if (File.Exists(destPath))
+                    {
+                        string nameNoExt = Path.GetFileNameWithoutExtension(destPath);
+                        string ext = Path.GetExtension(destPath);
+                        string stamp = DateTime.Now.ToString("yyyyMMdd_HHmmssfff");
+                        destPath = Path.Combine(destDir, nameNoExt + "_" + stamp + ext);
+                    }
+
+                    File.Move(f, destPath);
+                    if (writeToConsole)
+                    {
+                        Console.WriteLine("Moved " + f + " -> " + destPath);
+                    }
+                }
+                catch (Exception e)
+                {
+                    Console.WriteLine("Failed to move file '" + f + "': " + e);
                 }
             }
         }

--- a/NEWDecodeandImportASC3Logs/Program.cs
+++ b/NEWDecodeandImportASC3Logs/Program.cs
@@ -100,8 +100,7 @@ namespace NEWDecodeandImportASC3Logs
                 Convert.ToInt32(appSettings["BulkCopyBatchSize"]),
                 Convert.ToInt32(appSettings["BulkCopyTimeOut"]));
 
-            bool moveEnabled = false;
-            bool.TryParse(appSettings["Move"], out moveEnabled);
+            bool moveEnabled = Convert.ToBoolean(appSettings["Move"]);
             string moveLocation = appSettings["MoveLocation"];
             bool useMove = moveEnabled && !string.IsNullOrWhiteSpace(moveLocation);
 


### PR DESCRIPTION
- added new settings Move and MoveLocation to read from
- BulkImportRecordsAndDeleteFiles
- now reads in SignId so that way MoveFiles knows what subfolder to create in the destination
- reads in the settings and has a check to make sure both are valid
- checks ifMove is true if not delete
- MoveFiles func
- first try to make a subfolder for the signla inside the archive location 
- go through each file in loop
- build destination 
- if the file name exists already add datetime just so there is never an overwrite
- and some log statements